### PR TITLE
Add fuzzer_decoder.dict

### DIFF
--- a/fuzzer_decoder.dict
+++ b/fuzzer_decoder.dict
@@ -1,0 +1,6 @@
+flac_stream_marker="fLaC"
+ogg_stream_marker="OggS"
+flac_in_ogg_marker="\x7fFLAC"
+
+synccode_fixed_blocksize="\xFF\xF8"
+synccode_variable_blocksize="\xFF\xF9"


### PR DESCRIPTION
Add fuzzer decoder dictionary with sync codes and stream markers. Test run without corpus indicates a 15% increase in coverage with 10 minutes of fuzzing.